### PR TITLE
Fix GitHub Actions workflow to avoid bundler conflicts

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,11 +32,16 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3.9'
+          bundler: none  # Don't install bundler at all
 
       - name: Install dependencies
         run: |
           gem install jekyll -v 4.4.0
-          gem install minima jekyll-feed jekyll-sitemap jekyll-seo-tag webrick
+          gem install minima -v 2.5.2
+          gem install jekyll-feed -v 0.17.0
+          gem install jekyll-sitemap -v 1.4.0
+          gem install jekyll-seo-tag -v 2.8.0
+          gem install webrick -v 1.9.1
 
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
- Set bundler: none to prevent old bundler installation
- Use specific gem versions for consistent builds
- Avoid Ruby 3.3.9 + bundler 2.0.2 compatibility issues

🤖 Generated with [Claude Code](https://claude.ai/code)